### PR TITLE
Add TTS functionality for Danmaku messages

### DIFF
--- a/danmu/src/main.rs
+++ b/danmu/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
                     break;
                 }
             }
-            thread::sleep(Duration::new(0, 10));
+            thread::sleep(Duration::from_millis(10)); // instead of 10 microseconds
         }
     });
 
@@ -75,6 +75,23 @@ fn main() {
     let mut scheduler = Scheduler::new();
     let terminal_handler = Arc::new(TerminalDisplayHandler);
     scheduler.add_sequential_handler(terminal_handler);
+
+    // Add the TTS handler for macOS Chinese voice
+    #[cfg(target_os = "macos")]
+    {
+        use plugins::tts_handler;
+        let tts = tts_handler(
+            "say".to_string(),
+            vec!["-v".to_string(), "SinJi".to_string()],
+        );
+        scheduler.add_sequential_handler(tts);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        use plugins::tts_handler;
+        let tts = tts_handler("echo".to_string(), vec![]);
+        scheduler.add_sequential_handler(tts);
+    }
 
     // create a thread to process the rx channel messages using tokio runtime and pass to scheduler
     let rt = Runtime::new().unwrap();

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -47,8 +47,33 @@ flowchart TD
 - The TTS service converts the text into speech audio.
 - The plugin plays the generated audio in real time.
 
+### Usage
+
+Add the TTS plugin handler to your scheduler. You can specify the TTS command and arguments (for example, to use a Chinese voice on macOS):
+
+```rust
+use plugins::tts_handler;
+use client::scheduler::Scheduler;
+use std::sync::Arc;
+
+let mut scheduler = Scheduler::new();
+// For macOS Chinese voice:
+let tts = tts_handler(
+    "say".to_string(),
+    vec!["-v".to_string(), "SinJi".to_string()]
+);
+scheduler.add_sequential_handler(tts);
+```
+
+On other platforms, you can use a different TTS command, such as `echo` for testing:
+
+```rust
+let tts = tts_handler("echo".to_string(), vec![]);
+scheduler.add_sequential_handler(tts);
+```
+
 ### Implementation
 
-The TTS plugin implements the `EventHandler` trait. On receiving a `Danmaku` event, it processes the message as described above.
+The TTS plugin implements the `EventHandler` trait. On receiving a `Danmaku` event, it processes the message as described above, passing the text to the configured TTS command with any additional arguments.
 
 This allows you to add voice feedback to your live room, making interactions more engaging and accessible.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -27,3 +27,28 @@ When a message is triggered, the handler will print it to the terminal.
 To add a new plugin, implement the `EventHandler` trait for your struct and register it with the scheduler.
 
 ---
+
+## TTS Plugin
+
+The TTS (Text-to-Speech) plugin enables your application to read out text messages using a TTS service. This service can be either local or remote.
+
+### How it works
+
+```mermaid
+flowchart TD
+    A[User sends Danmaku message] --> B[TTS Plugin receives Danmaku event]
+    B --> C[Send message text to TTS service]
+    C --> D[TTS service returns speech audio]
+    D --> E[Plugin plays audio in real time]
+```
+
+- When a user sends a message (Danmaku event) in the live room, the plugin receives the event.
+- The plugin sends the message text to the configured TTS service.
+- The TTS service converts the text into speech audio.
+- The plugin plays the generated audio in real time.
+
+### Implementation
+
+The TTS plugin implements the `EventHandler` trait. On receiving a `Danmaku` event, it processes the message as described above.
+
+This allows you to add voice feedback to your live room, making interactions more engaging and accessible.

--- a/plugins/src/lib.rs
+++ b/plugins/src/lib.rs
@@ -1,10 +1,17 @@
 pub mod terminal_display;
+pub mod tts;
+
 use client::scheduler::EventHandler;
 use std::sync::Arc;
 
 /// Helper to create the handler as Arc<dyn EventHandler>
 pub fn terminal_display_handler() -> Arc<dyn EventHandler> {
     Arc::new(terminal_display::TerminalDisplayHandler)
+}
+
+/// Helper to create the TTS handler as Arc<dyn EventHandler>
+pub fn tts_handler(tts_command: String, tts_args: Vec<String>) -> Arc<dyn EventHandler> {
+    Arc::new(tts::TtsHandler::new(tts_command, tts_args))
 }
 
 #[cfg(test)]

--- a/plugins/src/tts.rs
+++ b/plugins/src/tts.rs
@@ -1,0 +1,66 @@
+use client::models::BiliMessage;
+use client::scheduler::EventHandler;
+use std::process::Command;
+
+/// A plugin that sends Danmaku text to a TTS service and plays the audio.
+pub struct TtsHandler {
+    /// The TTS command to use (e.g., "say" on macOS, or a custom script)
+    pub tts_command: String,
+    /// Optional extra arguments for the TTS command (e.g., ["-v", "SinJi"])
+    pub tts_args: Vec<String>,
+}
+
+impl TtsHandler {
+    pub fn new(tts_command: String, tts_args: Vec<String>) -> Self {
+        TtsHandler {
+            tts_command,
+            tts_args,
+        }
+    }
+}
+
+impl EventHandler for TtsHandler {
+    fn handle(&self, msg: &BiliMessage) {
+        if let BiliMessage::Danmu { user, text } = msg {
+            let message = format!("{}说：{}", user, text);
+            let mut cmd = Command::new(&self.tts_command);
+            for arg in &self.tts_args {
+                cmd.arg(arg);
+            }
+            let _ = cmd.arg(&message).spawn();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use client::models::BiliMessage;
+    use client::scheduler::EventHandler;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_tts_handler_danmu() {
+        let handler = TtsHandler::new(
+            "say".to_string(),
+            vec!["-v".to_string(), "SinJi".to_string()],
+        );
+        let text = "您好，我叫SinJi。我讲普通话。".to_string();
+        let msg = BiliMessage::Danmu {
+            user: "test user".to_string(),
+            text: text.clone(),
+        };
+        handler.handle(&msg);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn test_tts_handler_danmu() {
+        let handler = TtsHandler::new("echo".to_string(), vec![]);
+        let msg = BiliMessage::Danmu {
+            user: "test_user".to_string(),
+            text: "hello world".to_string(),
+        };
+        handler.handle(&msg);
+    }
+}


### PR DESCRIPTION
Implement a Text-to-Speech (TTS) plugin that converts Danmaku messages to voice, enhancing user interaction. The TTS handler is configured for both macOS and non-macOS environments, allowing for real-time audio playback of messages. Documentation has been added to guide users on how to utilize the TTS plugin effectively.